### PR TITLE
Rename package to soundfile (pysoundfile transition metapackage)

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -23,80 +23,89 @@ jobs:
       matrix:
         include:
           - CONFIG: linux_64_
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
-            os: ubuntu
-            runs_on: ['ubuntu-latest']
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-            tools_install_dir: ~/miniforge3
             build_workspace_dir: build_artifacts
             docker_run_args: 
+            free_disk_space: skip
+            os: ubuntu
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['ubuntu-latest']
+            tools_install_dir: ~/miniforge3
     steps:
 
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Configure binfmt_misc
+      if: matrix.os == 'ubuntu'
+      shell: bash
+      run: |
+        if [[ "$(uname -m)" == "x86_64" ]]; then
+          docker run --rm --privileged multiarch/qemu-user-static:register --reset --credential yes
+        fi
 
     - name: Build on Linux
       id: build-linux
       if: matrix.os == 'ubuntu'
       env:
-        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
-        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
-        CONFIG: ${{ matrix.CONFIG }}
-        UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
-        DOCKER_IMAGE: ${{ matrix.DOCKER_IMAGE }}
         CI: github_actions
-        CONDA_FORGE_DOCKER_RUN_ARGS: "${{ matrix.docker_run_args }}"
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
+        CONDA_FORGE_DOCKER_RUN_ARGS: ${{ matrix.docker_run_args }}
+        CONFIG: ${{ matrix.CONFIG }}
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        DOCKER_IMAGE: ${{ matrix.DOCKER_IMAGE }}
+        UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
+        RATTLER_BUILD_COLOR: always
+        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
         FEEDSTOCK_TOKEN: ${{ secrets.FEEDSTOCK_TOKEN }}
         STAGING_BINSTAR_TOKEN: ${{ secrets.STAGING_BINSTAR_TOKEN }}
       shell: bash
       run: |
-        if [[ "$(uname -m)" == "x86_64" ]]; then
-          echo "::group::Configure binfmt_misc"
-          docker run --rm --privileged multiarch/qemu-user-static:register --reset --credential yes
-        fi
+        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
+        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
+        export GIT_BRANCH="$(basename $GITHUB_REF)"
+        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
         export flow_run_id="github_$GITHUB_RUN_ID"
         export remote_url="https://github.com/$GITHUB_REPOSITORY"
         export sha="$GITHUB_SHA"
-        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
-        export GIT_BRANCH="$(basename $GITHUB_REF)"
         if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
           export IS_PR_BUILD="True"
         else
           export IS_PR_BUILD="False"
         fi
-        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
-        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
-        echo "::endgroup::"
         ./.scripts/run_docker_build.sh
 
     - name: Build on macOS
       id: build-macos
       if: matrix.os == 'macos'
       env:
-        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        CI: github_actions
         CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
         CONFIG: ${{ matrix.CONFIG }}
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
         UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
-        CI: github_actions
+        RATTLER_BUILD_COLOR: always
+        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
         FEEDSTOCK_TOKEN: ${{ secrets.FEEDSTOCK_TOKEN }}
         STAGING_BINSTAR_TOKEN: ${{ secrets.STAGING_BINSTAR_TOKEN }}
       shell: bash
       run: |
+        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
+        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
+        export GIT_BRANCH="$(basename $GITHUB_REF)"
+        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
         export flow_run_id="github_$GITHUB_RUN_ID"
         export remote_url="https://github.com/$GITHUB_REPOSITORY"
         export sha="$GITHUB_SHA"
-        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
-        export GIT_BRANCH="$(basename $GITHUB_REF)"
         if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
           export IS_PR_BUILD="True"
         else
           export IS_PR_BUILD="False"
         fi
-        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
-        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
         ./.scripts/run_osx_build.sh
 
     - name: Build on windows
@@ -109,12 +118,14 @@ jobs:
         set "sha=%GITHUB_SHA%"
         call ".scripts\run_win_build.bat"
       env:
-        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
-        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
-        PYTHONUNBUFFERED: 1
-        CONFIG: ${{ matrix.CONFIG }}
         CI: github_actions
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
+        CONFIG: ${{ matrix.CONFIG }}
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        PYTHONUNBUFFERED: 1
         UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
+        RATTLER_BUILD_COLOR: always
+        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
         FEEDSTOCK_TOKEN: ${{ secrets.FEEDSTOCK_TOKEN }}
         STAGING_BINSTAR_TOKEN: ${{ secrets.STAGING_BINSTAR_TOKEN }}

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -66,16 +66,37 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
 fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    echo "rattler-build currently doesn't support debug mode"
-else
+    # differences between conda-build vs. rattler-build
+    #   - 1 step (conda debug + manually open shell) vs. 2 step (rb debug {setup, shell})
+    #   - recipe is positional vs. --recipe "${RECIPE_ROOT}"
+    #   - --output-id vs. --output-name
+    #   - --clobber-file vs. none
+    #   - none vs. --target-platform
+    export CONDA_BLD_PATH="${CONDA_BLD_PATH:-${FEEDSTOCK_ROOT}/build_artifacts}"
+    rattler-build debug setup \
+        --recipe "${RECIPE_ROOT}" \
+        -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+        ${EXTRA_CB_OPTIONS:-} \
+        ${BUILD_OUTPUT_ID:+--output-name "${BUILD_OUTPUT_ID}"} \
+        --target-platform "${HOST_PLATFORM}"
 
-    rattler-build build --recipe "${RECIPE_ROOT}" \
-     -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-     ${EXTRA_CB_OPTIONS:-} \
-     --target-platform "${HOST_PLATFORM}" \
-     --extra-meta flow_run_id="${flow_run_id:-}" \
-     --extra-meta remote_url="${remote_url:-}" \
-     --extra-meta sha="${sha:-}"
+    rattler-build debug shell
+else
+    # differences between conda-build vs. rattler-build
+    #   - recipe is positional vs. --recipe "${RECIPE_ROOT}"
+    #   - --suppress-variables vs. none
+    #   - --clobber-file vs. none
+    #   - none vs. --target-platform
+    #   - --extra-meta a=b c=d vs. --extra-meta a=b --extra-meta c=d
+
+    rattler-build build \
+        --recipe "${RECIPE_ROOT}" \
+        -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+        ${EXTRA_CB_OPTIONS:-} \
+        --target-platform "${HOST_PLATFORM}" \
+        --extra-meta flow_run_id="${flow_run_id:-}" \
+        --extra-meta remote_url="${remote_url:-}" \
+        --extra-meta sha="${sha:-}"
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 
     # inspect_artifacts was only added in conda-forge-ci-setup 4.9.4

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -96,6 +96,14 @@ if [ "${DOCKER_EXECUTABLE}" = "podman" ]; then
     fi
 fi
 
+# When running on GitHub Actions, mount the step summary file into the container
+# and point GITHUB_STEP_SUMMARY at it so that rattler-build's GitHub integration
+# can write its summary. GitHub writes the file out to the job summary after the
+# step finishes.
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    DOCKER_RUN_ARGS="${DOCKER_RUN_ARGS} -v ${GITHUB_STEP_SUMMARY}:/home/conda/github_step_summary:rw${VOLUME_SUFFIX},delegated -e GITHUB_STEP_SUMMARY=/home/conda/github_step_summary"
+fi
+
 ( endgroup "Configure Docker" ) 2> /dev/null
 ( startgroup "Start Docker" ) 2> /dev/null
 
@@ -107,17 +115,20 @@ ${DOCKER_EXECUTABLE} pull "${DOCKER_IMAGE}"
 ${DOCKER_EXECUTABLE} run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw${VOLUME_SUFFIX},delegated \
            -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw${VOLUME_SUFFIX},delegated \
-           -e CONFIG \
-           -e HOST_USER_ID \
-           -e UPLOAD_PACKAGES \
-           -e IS_PR_BUILD \
-           -e GIT_BRANCH \
-           -e UPLOAD_ON_BRANCH \
-           -e CI \
-           -e FEEDSTOCK_NAME \
-           -e CPU_COUNT \
-           -e BUILD_WITH_CONDA_DEBUG \
            -e BUILD_OUTPUT_ID \
+           -e BUILD_WITH_CONDA_DEBUG \
+           -e CI \
+           -e CONFIG \
+           -e CPU_COUNT \
+           -e FEEDSTOCK_NAME \
+           -e GIT_BRANCH \
+           -e GITHUB_ACTIONS \
+           -e HOST_USER_ID \
+           -e IS_PR_BUILD \
+           -e RATTLER_BUILD_COLOR \
+           -e RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION \
+           -e UPLOAD_ON_BRANCH \
+           -e UPLOAD_PACKAGES \
            -e flow_run_id \
            -e remote_url \
            -e sha \

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-pysoundfile-green.svg)](https://anaconda.org/conda-forge/pysoundfile) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pysoundfile.svg)](https://anaconda.org/conda-forge/pysoundfile) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pysoundfile.svg)](https://anaconda.org/conda-forge/pysoundfile) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pysoundfile.svg)](https://anaconda.org/conda-forge/pysoundfile) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-soundfile-green.svg)](https://anaconda.org/conda-forge/soundfile) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/soundfile.svg)](https://anaconda.org/conda-forge/soundfile) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/soundfile.svg)](https://anaconda.org/conda-forge/soundfile) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/soundfile.svg)](https://anaconda.org/conda-forge/soundfile) |
 
 Installing pysoundfile
 ======================
@@ -42,16 +43,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `pysoundfile` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `pysoundfile, soundfile` can be installed with `conda`:
 
 ```
-conda install pysoundfile
+conda install pysoundfile soundfile
 ```
 
 or with `mamba`:
 
 ```
-mamba install pysoundfile
+mamba install pysoundfile soundfile
 ```
 
 It is possible to list all of the versions of `pysoundfile` available on your platform with `conda`:

--- a/build-locally.py
+++ b/build-locally.py
@@ -98,7 +98,10 @@ def main(args=None):
     p.add_argument(
         "--debug",
         action="store_true",
-        help="Setup debug environment using `conda debug`",
+        help=(
+            "Setup debug environment using `conda debug` "
+            "(or `rattler-build debug` for rattler-build recipes)"
+        ),
     )
     p.add_argument("--output-id", help="If running debug, specify the output to setup.")
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -5,7 +5,7 @@
 
 [workspace]
 name = "pysoundfile-feedstock"
-version = "2026.5.29"  # conda-smithy version used to generate this file
+version = "2026.6.14"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/pysoundfile-feedstock"
 authors = ["@conda-forge/pysoundfile"]
 channels = ["conda-forge"]

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,10 +1,9 @@
 context:
-  name: pysoundfile
   pypi_name: soundfile
   version: "0.14.0"
 
-package:
-  name: ${{ name|lower }}
+recipe:
+  name: soundfile
   version: ${{ version }}
 
 source:
@@ -18,49 +17,71 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script:
-    # We are currently building a noarch package, but pysoundfile contains an
-    # install-time check for the OS and injects the sf_wchar_open function
-    # conditionally. If this variable is not set, opening files on Windows doesn't work.
-    # Original issue on conda-forge: https://github.com/conda-forge/libsndfile-feedstock/issues/14
-    env:
-      PYSOUNDFILE_PLATFORM: win32
-    content:
-      - python -m pip install . --no-deps -vv
 
-requirements:
-  host:
-    - pip
-    - python ${{ python_min }}.*
-    - setuptools
-    - cffi
-  run:
-    - python >=${{ python_min }}
-    - cffi >=1.0
-    - numpy
-    - typing_extensions
-    - libsndfile >=1.2
-
-tests:
-  - python:
-      imports:
-        - soundfile
-      pip_check: true
-      python_version: ${{ python_min }}.*
-  - script:
-      # Verify that soundfile is linking the correct libsndfile object
-      - python -c "import soundfile; print(soundfile._libname)"
-      # Verify that we can actually access the library
-      - python -c "import soundfile as sf, pprint; fmts = sf.available_formats(); pprint.pprint(fmts); assert 'WAV' in fmts"
-      # Functional round-trip test: write and read back a WAV file
-      - python run_test.py
+outputs:
+  - package:
+      name: soundfile
+    build:
+      noarch: python
+      script:
+        # We are currently building a noarch package, but soundfile contains an
+        # install-time check for the OS and injects the sf_wchar_open function
+        # conditionally. If this variable is not set, opening files on Windows doesn't work.
+        # Original issue on conda-forge: https://github.com/conda-forge/libsndfile-feedstock/issues/14
+        env:
+          PYSOUNDFILE_PLATFORM: win32
+        content:
+          - python -m pip install . --no-deps -vv
     requirements:
-      run:
+      host:
+        - pip
         - python ${{ python_min }}.*
-    files:
-      recipe:
-        - run_test.py
+        - setuptools
+        - cffi
+      run:
+        - python >=${{ python_min }}
+        - cffi >=1.0
+        - numpy
+        - typing_extensions
+        - libsndfile >=1.2
+    tests:
+      - python:
+          imports:
+            - soundfile
+          pip_check: true
+          python_version: ${{ python_min }}.*
+      - script:
+          # Verify that soundfile is linking the correct libsndfile object
+          - python -c "import soundfile; print(soundfile._libname)"
+          # Verify that we can actually access the library
+          - python -c "import soundfile as sf, pprint; fmts = sf.available_formats(); pprint.pprint(fmts); assert 'WAV' in fmts"
+          # Functional round-trip test: write and read back a WAV file
+          - python run_test.py
+        requirements:
+          run:
+            - python ${{ python_min }}.*
+        files:
+          recipe:
+            - run_test.py
+
+  # Transition metapackage: the project was renamed from `pysoundfile` to
+  # `soundfile`. This keeps the old name installable while pointing users at
+  # the renamed package. See https://github.com/conda-forge/pysoundfile-feedstock/issues/23
+  - package:
+      name: pysoundfile
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python ${{ python_min }}.*
+      run:
+        - python >=${{ python_min }}
+        - ${{ pin_subpackage('soundfile', exact=True) }}
+    tests:
+      - python:
+          imports:
+            - soundfile
+          python_version: ${{ python_min }}.*
 
 about:
   homepage: https://python-soundfile.readthedocs.io/


### PR DESCRIPTION
## Summary

Follow-up to #29. The upstream project was renamed `pysoundfile` → `soundfile` (the import name has been `soundfile` for a while). This builds the package under the canonical **`soundfile`** name and keeps a **`pysoundfile`** transition metapackage that depends on `${{ pin_subpackage('soundfile', exact=True) }}`, so existing `pysoundfile` installs keep working.

Closes #23.

## Testing
Built locally with `rattler-build build --recipe recipe -m .ci_support/linux_64_.yaml` — both `soundfile` and `pysoundfile` outputs build and all tests pass. `conda-smithy lint` is clean.

## Notes for merge
- `soundfile` is a new output name for this feedstock. With no other feedstock claiming it, conda-forge output validation should auto-register it on first upload — worth a quick check on the post-merge upload.
- The **feedstock repo rename** (`pysoundfile-feedstock` → `soundfile-feedstock`) is a separate org-level operation and is not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)